### PR TITLE
Input Sanitazation in callback and redirect

### DIFF
--- a/init.php
+++ b/init.php
@@ -350,7 +350,7 @@ class Herepay_WC_Payment_Gateway extends WC_Payment_Gateway {
         if (isset($_POST['payment_data']) && is_array($_POST['payment_data'])) {
             // Sanitize array structure immediately
             $sanitized_data = array();
-            // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Sanitized in loop below
+            // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.NonceVerification.Missing -- Sanitized in loop below, called within WooCommerce checkout context
             foreach ($_POST['payment_data'] as $item) {
                 if (is_array($item)) {
                     $sanitized_data[] = array(

--- a/init.php
+++ b/init.php
@@ -340,7 +340,6 @@ class Herepay_WC_Payment_Gateway extends WC_Payment_Gateway {
      * Note: $_POST access is safe here as this is called within WooCommerce's secure checkout context
      */
     public function get_payment_post_data($key) {
-        var_dump($_POST, $key);
         // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Called within WooCommerce checkout context
         if (isset($_POST[$key]) && !empty($_POST[$key])) {
             // phpcs:ignore WordPress.Security.NonceVerification.Missing

--- a/init.php
+++ b/init.php
@@ -340,31 +340,18 @@ class Herepay_WC_Payment_Gateway extends WC_Payment_Gateway {
      * Note: $_POST access is safe here as this is called within WooCommerce's secure checkout context
      */
     public function get_payment_post_data($key) {
+        var_dump($_POST, $key);
         // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Called within WooCommerce checkout context
         if (isset($_POST[$key]) && !empty($_POST[$key])) {
             // phpcs:ignore WordPress.Security.NonceVerification.Missing
             return sanitize_text_field(wp_unslash($_POST[$key]));
         }
         
+        // Access payment_data directly by index instead of looping
         // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Called within WooCommerce checkout context
-        if (isset($_POST['payment_data']) && is_array($_POST['payment_data'])) {
-            // Sanitize array structure immediately
-            $sanitized_data = array();
-            // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.NonceVerification.Missing -- Sanitized in loop below, called within WooCommerce checkout context
-            foreach ($_POST['payment_data'] as $item) {
-                if (is_array($item)) {
-                    $sanitized_data[] = array(
-                        'key' => isset($item['key']) ? sanitize_text_field(wp_unslash($item['key'])) : '',
-                        'value' => isset($item['value']) ? sanitize_text_field(wp_unslash($item['value'])) : '',
-                    );
-                }
-            }
-            
-            foreach ($sanitized_data as $data) {
-                if ($data['key'] === $key && !empty($data['value'])) {
-                    return $data['value'];
-                }
-            }
+        if (isset($_POST['payment_data'][$key]) && !empty($_POST['payment_data'][$key])) {
+            // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            return sanitize_text_field(wp_unslash($_POST['payment_data'][$key]));
         }
         
         // phpcs:ignore WordPress.Security.NonceVerification.Missing


### PR DESCRIPTION
improve input sanitization and simplify how we handle checkout/webhook data

– get_payment_post_data() now sanitizes block checkout arrays properly.
– handle_callback() and handle_herepay_redirect() loop through expected fields instead of repeating sanitization manually.
– Removed redundant variable assignments for cleaner code.